### PR TITLE
Lint with Shellcheck & improve README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Mapbox Route Visualizer is a powerful bash script that creates a visually ap
 - curl
 - jq (`brew install jq`)
 - ImageMagick (`brew install imagemagick`)
-- Mapbox account and access token
+- Mapbox account and access token (create a private one with _all_ scopes)
 
 ## Installation
 1. Clone this repository or download the `bash_mapbox_route_visualizer.sh` script.
@@ -28,7 +28,7 @@ The Mapbox Route Visualizer is a powerful bash script that creates a visually ap
 3. Ensure you have all the prerequisites installed.
 
 ## Configuration
-1. Set your Mapbox access token as an environment variable:
+1. Set your Mapbox access token (private with _all_ scopes) as an environment variable:
    ```
    export MAPBOX_ACCESS_TOKEN="your_mapbox_access_token_here"
    ```
@@ -45,7 +45,6 @@ This will execute the script and generate the map image based on the provided lo
 ## Credits
 This project was developed with the assistance of Claude Sonnet 3.5 and the team at Anthropic. Their support and contributions were invaluable in writing and refining the code.
 
-
 ## Disclaimer: Use at Your Own Risk
 
 This script is provided "as is" without any warranties or guarantees of any kind, either expressed or implied. The user assumes all responsibility and risk for the use of this script. The authors and contributors are not liable for any damages or losses resulting from the use or misuse of this script.
@@ -53,4 +52,3 @@ This script is provided "as is" without any warranties or guarantees of any kind
 Always review and test the script thoroughly before using it in any critical or production environment. It is recommended to use this script only for personal or educational purposes, and to exercise caution when working with APIs and external services.
 
 By using this script, you acknowledge that you have read this disclaimer, understand its contents, and agree to use the script at your own risk.
-

--- a/bash_mapbox_route_visualizer.sh
+++ b/bash_mapbox_route_visualizer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script was developed with the assistance of Claude Sonnet 3.5, an AI language model created by Anthropic.
 
@@ -18,8 +18,6 @@ locations=(
   "Pownal, ME|gray"
   "Deer Isle, ME|gray"
 )
-
-#!/bin/bash
 
 # Mapbox API parameters
 USERNAME="ankurkwv"
@@ -106,30 +104,30 @@ done
 for i in $(seq 0 $((${#geocoded_locations[@]} - 2))); do
     IFS='|' read -r start start_location start_color <<< "${geocoded_locations[$i]}"
     IFS='|' read -r end end_location end_color <<< "${geocoded_locations[$((i+1))]}"
-    
+
     route_color="$start_color"
-    
+
     # Get directions
     directions_url="https://api.mapbox.com/directions/v5/mapbox/driving/${start};${end}?geometries=geojson&overview=full&access_token=${ACCESS_TOKEN}"
     directions_response=$(curl -s "$directions_url")
     echo -e "  \033[0;32m✓\033[0m Fetched directions for ${start_location} to ${end_location}"
     route_geometry=$(echo "$directions_response" | jq -c '.routes[0].geometry')
-    
+
     # Extract and format distance and duration
     distance_miles=$(echo "$directions_response" | jq -r '.routes[0].distance | . / 1609.344')
     duration_hours=$(echo "$directions_response" | jq -r '.routes[0].duration | . / 3600')
     distance_miles=$(printf "%.2f" $distance_miles)
     duration_hours=$(printf "%.2f" $duration_hours)
-    
+
     # Update totals
     miles_total=$(echo "$miles_total + $distance_miles" | bc)
     hours_total=$(echo "$hours_total + $duration_hours" | bc)
-    
+
     if [ "$route_color" = "blue" ]; then
         visited_miles_total=$(echo "$visited_miles_total + $distance_miles" | bc)
         visited_hours_total=$(echo "$visited_hours_total + $duration_hours" | bc)
     fi
-    
+
     geojson+='{"type":"Feature","geometry":'"$route_geometry"',"properties":{"start":"'"$start_location"'","end":"'"$end_location"'","color":"'"$route_color"'"}},'
 done
 
@@ -221,7 +219,7 @@ while true; do
   PROGRESS=$(echo $STATUS_RESPONSE | jq -r '.progress')
   ERROR=$(echo $STATUS_RESPONSE | jq -r '.error')
   echo -e "  \033[0;36m•\033[0m Complete: $COMPLETE, Progress: $PROGRESS, Error: $ERROR"
-  
+
   if [ "$COMPLETE" = "true" ]; then
     if [ "$ERROR" != "null" ]; then
       echo -e "  \033[0;31m✗\033[0m Upload failed with error: $ERROR"
@@ -236,13 +234,13 @@ while true; do
     echo -e "  \033[0;31m✗\033[0m Unexpected completion status: $COMPLETE"
     exit 1
   fi
-  
+
   ATTEMPTS=$((ATTEMPTS + 1))
   if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
     echo -e "  \033[0;31m✗\033[0m Maximum number of attempts reached. Exiting."
     exit 1
   fi
-  
+
   sleep 5
 done
 
@@ -388,7 +386,7 @@ STYLE_JSON=$(cat <<EOF
         "circle-stroke-color": "#ffffff"
       },
       "filter": ["==", ["geometry-type"], "Point"]
-    }, 
+    },
     {
       "id": "point-labels",
       "type": "symbol",

--- a/bash_mapbox_route_visualizer.sh
+++ b/bash_mapbox_route_visualizer.sh
@@ -20,7 +20,7 @@ locations=(
 )
 
 # Mapbox API parameters
-USERNAME="ankurkwv"
+USERNAME="${MAPBOX_USERNAME:-ankurkwv}"
 ACCESS_TOKEN="$MAPBOX_ACCESS_TOKEN"
 TILESET_NAME="bash_mapbox_route_visualizer" # Can be anything!
 TODAYS_DATE=$(date "+%B %d, %Y")
@@ -137,14 +137,6 @@ done
 # Finalize GeoJSON
 geojson=${geojson%,}
 geojson+=']}'
-
-# Check if the file exists, if not create it
-if [ ! -f "route.geojson" ]; then
-    if ! touch route.geojson; then
-        echo -e "  \033[0;31m✗\033[0m Failed to create route.geojson. Exiting."
-        exit 1
-    fi
-fi
 
 # Write the GeoJSON to the file
 if ! echo "$geojson" > route.geojson; then


### PR DESCRIPTION
Tried this out locally. Cool stuff.

Main changes:

- Linted with [Shellcheck](https://www.shellcheck.net/)
- Allow for different username via env var
- Remove unnecessary logic of touching the geojson before writing it
- Clarity the access token scope (I needed to create a private one and ultimately added _all_ the scopes, maybe you know specifically which ones are required)